### PR TITLE
Refactor Card tests

### DIFF
--- a/test/Card-test.js
+++ b/test/Card-test.js
@@ -4,29 +4,17 @@ const expect = chai.expect;
 const Card = require("../src/Card");
 
 describe("Card", function() {
+ let card;
+ beforeEach(() => {
+  card = new Card(1, "What allows you to define a set of related information using key-value pairs?", ["object", "array", "function"], "object");
+})
+  it("should be a function", () => expect(Card).to.be.a("function"));
 
-  it("should be a function", function() {
-    const card = new Card();
-    expect(Card).to.be.a("function");
-  });
+  it("should be an instance of Card", () => expect(card).to.be.an.instanceof(Card));
 
-  it("should be an instance of Card", function() {
-    const card = new Card();
-    expect(card).to.be.an.instanceof(Card);
-  });
+  it("should store a question", () => expect(card.question).to.equal("What allows you to define a set of related information using key-value pairs?"));
 
-  it("should store a question", function() {
-    const card = new Card(1, "What allows you to define a set of related information using key-value pairs?", ["object", "array", "function"], "object");
-    expect(card.question).to.equal("What allows you to define a set of related information using key-value pairs?");
-  });
+  it("should store a list of possible answers", () => expect(card.answers).to.deep.equal(["object", "array", "function"]));
 
-  it("should store a list of possible answers", function() {
-    const card = new Card(1, "What allows you to define a set of related information using key-value pairs?", ["object", "array", "function"], "object");
-    expect(card.answers).to.deep.equal(["object", "array", "function"]);
-  });
-
-  it("should store the correct answer", function() {
-    const card = new Card(1, "What allows you to define a set of related information using key-value pairs?", ["object", "array", "function"], "object");
-    expect(card.correctAnswer).to.equal("object");
-  });
+  it("should store the correct answer", () => expect(card.correctAnswer).to.equal("object"));
 });


### PR DESCRIPTION
## Is this a fix or a feature?
Fix

## What is the change?
Refactoring code in test files to use beforeEach() hooks and ES6 big arrow functions in 'it' blocks.

## What does it fix?
Cleaner code

## Where should the reviewer start?
feature/card branch

## How should this be tested?
run `npm test` 